### PR TITLE
Feat: Switch chatbot to HTTP API and add FAB

### DIFF
--- a/view/templates/base.html
+++ b/view/templates/base.html
@@ -225,5 +225,49 @@
       copyright 2025 KONECTAi - Voluntariado Inclusivo
     </footer>
 
+    <!-- Floating Chatbot Icon and Menu -->
+    {% if not request.path == url_for('main.help_page') %}
+    <div id="chatbot-fab-container" class="fixed bottom-5 right-5 z-50">
+        <div id="chatbot-menu" class="hidden absolute bottom-16 right-0 mb-2 w-48 bg-white rounded-md shadow-lg py-1 text-sm text-gray-700 ring-1 ring-black ring-opacity-5">
+            <a href="{{ url_for('main.help_page') }}" class="block px-4 py-2 hover:bg-gray-100">Chatbot por Texto</a>
+            <a href="#" id="voice-chat-option" class="block px-4 py-2 hover:bg-gray-100 text-gray-400 cursor-not-allowed" title="Próximamente">Chatbot por Voz (Próximamente)</a>
+        </div>
+        <button id="chatbot-fab" class="bg-indigo-600 hover:bg-indigo-700 text-white rounded-full p-4 shadow-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+            </svg>
+        </button>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const fabContainer = document.getElementById('chatbot-fab-container');
+            if (fabContainer) { // Check if the container exists (it won't on help.html)
+                const fab = document.getElementById('chatbot-fab');
+                const menu = document.getElementById('chatbot-menu');
+                const voiceOption = document.getElementById('voice-chat-option');
+
+                fab.addEventListener('click', function() {
+                    menu.classList.toggle('hidden');
+                });
+
+                // Close menu if clicking outside
+                document.addEventListener('click', function(event) {
+                    if (!fab.contains(event.target) && !menu.contains(event.target)) {
+                        menu.classList.add('hidden');
+                    }
+                });
+
+                if (voiceOption) {
+                    voiceOption.addEventListener('click', function(e) {
+                        e.preventDefault();
+                        // Future: alert("Funcionalidad de chat por voz próximamente.");
+                    });
+                }
+            }
+        });
+    </script>
+    {% endif %}
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/view/templates/help.html
+++ b/view/templates/help.html
@@ -40,6 +40,6 @@
 
 {% block scripts %}
 {# {{ super() }} #}
-<script src="https://cdn.socket.io/4.5.2/socket.io.min.js"></script>
+{# <script src="https://cdn.socket.io/4.5.2/socket.io.min.js"></script> #} {# SocketIO no longer needed for chat client #}
 <script src="{{ url_for('static', filename='js/help_chat.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
- Modified `static/js/help_chat.js` to use the `/api/chatbot/conversation` HTTP endpoint for chat messages, replacing the SocketIO implementation.