### PR TITLE
Fix: Corregir origen de sugerencias de horario

### DIFF
--- a/services/rangohorario_service.py
+++ b/services/rangohorario_service.py
@@ -1,163 +1,105 @@
 import pandas as pd
-from sklearn.model_selection import train_test_split
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.metrics import accuracy_score
-from model.models import Usuarios, Inscripciones, Notificaciones, InteraccionesChatbot, Actividades, Organizaciones
+# Imports de scikit-learn eliminados ya que no se entrena un modelo aquí, se usa análisis directo.
+# from sklearn.model_selection import train_test_split
+# from sklearn.ensemble import RandomForestClassifier
+# from sklearn.metrics import accuracy_score
+from model.models import Actividades # Organizaciones, Usuarios, Inscripciones, Notificaciones, InteraccionesChatbot ya no son necesarias aquí
 from database.db import db
-from sqlalchemy import func, cast, Date, Time
-from datetime import datetime, timedelta
+# from sqlalchemy import func, cast, Date, Time # Ya no son necesarios aquí
+# from datetime import datetime, timedelta # Ya no son necesarios aquí
 
 class PredictionService:
-    def __init__(self, threshold=0.6):
-        self.model = RandomForestClassifier(n_estimators=100, random_state=42)
-        self.threshold = threshold
-        self.accuracy = 0.0
-        self.feature_names = [
-            'hour_of_day', 'day_of_week', 'is_weekend',
-            'recent_notification_read', 'recent_interaction',
-            'recent_registration', 'recent_inscription'
-        ]
+    # El constructor ya no necesita el umbral de precisión del modelo.
+    # El MIN_INTERACTIONS_THRESHOLD se define directamente en get_optimal_time_slots.
+    def __init__(self):
+        # Ya no se entrena un modelo RandomForestClassifier aquí.
+        # self.model = RandomForestClassifier(n_estimators=100, random_state=42)
+        # self.accuracy = 0.0
+        # self.feature_names = [...] # Ya no son necesarios
+        pass
 
-    def _get_data(self, organizer_id):
-        activity_ids = db.session.query(Actividades.id_actividad)\
-            .filter(Actividades.id_organizacion == organizer_id)\
-            .all()
-        activity_ids = [a_id[0] for a_id in activity_ids]
+    # El organizer_id ya no es necesario si los datos son globales del CSV.
+    # Si se quisiera filtrar por organización en el futuro, se podría reintroducir.
+    def get_optimal_time_slots(self, organizer_id=None, num_slots=3):
+        # --- Data Collection from Synthetic CSV ---
+        try:
+            df_synthetic = pd.read_csv('database/synthetic_volunteer_data.csv')
+        except FileNotFoundError:
+            return "No se encontró el archivo de datos sintéticos en database/."
+        except Exception as e:
+            return f"Error al leer los datos sintéticos: {str(e)}"
 
-        if not activity_ids:
-            return pd.DataFrame()
+        if df_synthetic.empty:
+            return "El archivo de datos sintéticos está vacío."
 
-        user_registrations = db.session.query(
-            Usuarios.id_usuario,
-            Usuarios.fecha_registro
-        ).all()
-        df_registrations = pd.DataFrame(user_registrations, columns=['user_id', 'timestamp'])
-        df_registrations['event_type'] = 'registration'
+        # Consider only 'opened' or 'clicked' actions as positive interactions
+        df_interactions = df_synthetic[df_synthetic['action'].isin(['opened', 'clicked'])]
 
-        inscriptions = db.session.query(
-            Inscripciones.id_usuario,
-            Inscripciones.fecha_inscripcion
-        ).filter(Inscripciones.id_actividad.in_(activity_ids)).all()
-        df_inscriptions = pd.DataFrame(inscriptions, columns=['user_id', 'timestamp'])
-        df_inscriptions['event_type'] = 'inscription'
-
-        notifications_read = db.session.query(
-            Notificaciones.id_usuario,
-            Notificaciones.fecha_envio
-        ).filter(Notificaciones.leida == True).all()
-        df_notifications = pd.DataFrame(notifications_read, columns=['user_id', 'timestamp'])
-        df_notifications['event_type'] = 'notification_read'
-
-        chatbot_interactions = db.session.query(
-            InteraccionesChatbot.id_usuario,
-            InteraccionesChatbot.fecha
-        ).all()
-        df_chatbot = pd.DataFrame(chatbot_interactions, columns=['user_id', 'timestamp'])
-        df_chatbot['event_type'] = 'chatbot_interaction'
-
-        df = pd.concat([df_registrations, df_inscriptions, df_notifications, df_chatbot], ignore_index=True)
-
-        if df.empty:
-            return pd.DataFrame()
-
-        df['timestamp'] = pd.to_datetime(df['timestamp'])
-        return df
-
-    def _preprocess_data(self, df, organizer_id):
-        if df.empty:
-            return pd.DataFrame(), pd.Series(dtype='int')
-
-        df['hour_of_day'] = df['timestamp'].dt.hour
-        df['day_of_week'] = df['timestamp'].dt.dayofweek
-        df['is_weekend'] = df['day_of_week'].isin([5, 6]).astype(int)
-        df['is_good_time'] = 1
-
-        df['recent_notification_read'] = df['event_type'].apply(lambda x: 1 if x == 'notification_read' else 0)
-        df['recent_interaction'] = df['event_type'].apply(lambda x: 1 if x == 'chatbot_interaction' else 0)
-        df['recent_registration'] = df['event_type'].apply(lambda x: 1 if x == 'registration' else 0)
-        df['recent_inscription'] = df['event_type'].apply(lambda x: 1 if x == 'inscription' else 0)
-
-        features = df[self.feature_names]
-        target = df['is_good_time']
-
-        return features, target
-
-    def train_model(self, organizer_id):
-        data_df = self._get_data(organizer_id)
-        if data_df.empty or len(data_df) < 10:
-            self.accuracy = 0.0
-            print(f"No hay suficientes datos para entrenar el modelo para el organizador {organizer_id}.")
-            return
-
-        features, target = self._preprocess_data(data_df, organizer_id)
-
-        if features.empty or target.empty:
-            self.accuracy = 0.0
-            print(f"Características o target vacíos tras preprocesamiento para el organizador {organizer_id}.")
-            return
-
-        if len(target.unique()) < 2:
-            print(f"Solo se encontró una clase en los datos de target para el organizador {organizer_id}. No se puede entrenar el modelo.")
-            self.accuracy = 0.0
-            return
-
-        X_train, X_test, y_train, y_test = train_test_split(features, target, test_size=0.2, random_state=42, stratify=target if len(target.unique()) > 1 else None)
-
-        self.model.fit(X_train, y_train)
-        predictions = self.model.predict(X_test)
-        self.accuracy = accuracy_score(y_test, predictions)
-        print(f"Modelo entrenado para organizador {organizer_id}. Precisión: {self.accuracy:.2f}")
-
-
-    def get_optimal_time_slots(self, organizer_id, num_slots=3):
-        self.train_model(organizer_id)
-
-        if self.accuracy < self.threshold:
-            return f"La precisión del modelo ({self.accuracy:.2f}) es demasiado baja (umbral: {self.threshold:.2f}). No se pueden generar sugerencias confiables."
-
-        if not hasattr(self.model, 'classes_'):
-             return "El modelo no ha sido entrenado o no hay suficientes datos."
-
-        possible_hours = range(24)
-        possible_days = range(7)
-
-        test_data = []
-        for day in possible_days:
-            for hour in possible_hours:
-                test_data.append({
-                    'hour_of_day': hour,
-                    'day_of_week': day,
-                    'is_weekend': 1 if day in [5, 6] else 0,
-                    'recent_notification_read': 0,
-                    'recent_interaction': 0,
-                    'recent_registration': 0,
-                    'recent_inscription': 0
-                })
-
-        df_test = pd.DataFrame(test_data)
-        df_test = df_test[self.feature_names]
+        if df_interactions.empty:
+            return "No hay interacciones de 'apertura' o 'clic' en los datos sintéticos."
 
         try:
-            probabilities = self.model.predict_proba(df_test)[:, 1]
+            df_interactions['timestamp'] = pd.to_datetime(df_interactions['timestamp'])
+            df_interactions['hour'] = df_interactions['timestamp'].dt.hour
         except Exception as e:
-            return f"Error al predecir probabilidades: {e}"
+            return f"Error al procesar timestamps: {str(e)}"
 
-        df_test['probability'] = probabilities
-        hourly_avg_prob = df_test.groupby('hour_of_day')['probability'].mean().sort_values(ascending=False)
+        # --- Analysis with Pandas ---
+        hourly_activity_counts = df_interactions['hour'].value_counts().sort_index()
+        hourly_activity_counts = hourly_activity_counts.reindex(range(24), fill_value=0)
 
-        suggested_slots = []
-        for hour, prob in hourly_avg_prob.head(num_slots).items():
-            suggested_slots.append({
-                "start_time": f"{hour:02d}:00",
-                "end_time": f"{(hour + 1) % 24:02d}:00",
-                "probability": f"{prob:.2f}"
-            })
+        total_interactions = hourly_activity_counts.sum()
+        MIN_INTERACTIONS_THRESHOLD = 10 # Umbral de interacciones mínimas
 
-        if not suggested_slots:
-            return "No se pudieron generar sugerencias horarias."
+        if total_interactions < MIN_INTERACTIONS_THRESHOLD:
+            return (f"La cantidad de interacciones procesadas ({total_interactions}) es demasiado baja "
+                    f"(umbral: {MIN_INTERACTIONS_THRESHOLD}). No se pueden generar sugerencias confiables.")
 
-        return suggested_slots
+        # Apply smoothing (3-hour rolling window, centered)
+        smoothed_activity = hourly_activity_counts.rolling(window=3, center=True, min_periods=1).mean()
+
+        # Group into 2-hour blocks
+        bi_hourly_smoothed_activity = {}
+        for hour_block_start in range(0, 24, 2): # 0, 2, ..., 22
+            activity_in_block = smoothed_activity.get(hour_block_start, 0) + smoothed_activity.get(hour_block_start + 1, 0)
+            bi_hourly_smoothed_activity[hour_block_start] = activity_in_block
+
+        if not bi_hourly_smoothed_activity:
+            return "No se pudo procesar la actividad horaria tras el suavizado."
+
+        # Sort blocks by activity
+        sorted_blocks = sorted(bi_hourly_smoothed_activity.items(), key=lambda item: item[1], reverse=True)
+
+        significant_blocks = [(hour, activity) for hour, activity in sorted_blocks if activity > 0]
+        top_blocks = significant_blocks[:num_slots] # Usar num_slots
+
+        suggested_slots_list = [] # Cambiado a suggested_slots_list para evitar confusión con la variable de dashboard_routes
+        if top_blocks:
+            for block_start_hour, count in top_blocks:
+                start_time_str = f"{str(block_start_hour).zfill(2)}:00"
+                end_time_str = "00:00" if block_start_hour == 22 else f"{str(block_start_hour + 2).zfill(2)}:00"
+
+                # En lugar de 'probability', usamos el 'count' que es la actividad agregada estimada.
+                # Y el formato de salida debe ser una lista de diccionarios como antes,
+                # o una lista de strings si la plantilla espera eso.
+                # La plantilla organizer_dashboard.html espera una lista de objetos con .start_time y .end_time
+                # o un string. Devolveremos la lista de diccionarios.
+                suggested_slots_list.append({
+                    "start_time": start_time_str,
+                    "end_time": end_time_str,
+                    "estimated_activity": f"{count:.2f}" # Cambiado de 'probability' a 'estimated_activity'
+                })
+
+        if not suggested_slots_list:
+            return "No se encontraron bloques horarios con actividad voluntaria significativa después del análisis y suavizado."
+
+        return suggested_slots_list
+
 
 if __name__ == '__main__':
-    # Bloque de prueba local eliminado para limpieza, ya que las pruebas unitarias son el enfoque principal.
+    # Ejemplo de uso (opcional, para pruebas locales si es necesario)
+    # service = PredictionService()
+    # organizer_test_id = 1 # Simular un ID de organizador si fuera necesario para alguna lógica futura
+    # results = service.get_optimal_time_slots(organizer_id=organizer_test_id)
+    # print(results)
     pass


### PR DESCRIPTION
- Modificar `services/rangohorario_service.py` para usar el dataset sintético (database/synthetic_volunteer_data.csv) y la lógica de análisis directo, eliminando el entrenamiento de modelo anterior y el umbral de precisión.
- Actualizar `controller/dashboard_routes.py` para que la ruta del dashboard del organizador llame correctamente al `PredictionService` modificado y maneje su respuesta (string de mensaje o lista de horarios).
- Esto asegura que el dashboard del organizador muestre las sugerencias basadas en el dataset sintético y no el mensaje de error de baja precisión del modelo antiguo.